### PR TITLE
Fix externally-managed-environment error for Linux

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,10 +10,7 @@ warnings.filterwarnings("ignore", message=".*Trying to convert audio automatical
 warnings.filterwarnings("ignore", message=".*pad_token_id.*")
 warnings.filterwarnings("ignore", message=".*Setting `pad_token_id`.*")
 
-# Only attempt flash-attn install on Linux (HF Spaces)
-if sys.platform == "linux":
-    import subprocess
-    subprocess.run('pip install flash-attn --no-build-isolation', env={'FLASH_ATTENTION_SKIP_CUDA_BUILD': "TRUE"}, shell=True)
+# Flash-attn is installed via torch.js during Pinokio install - no runtime install needed
 
 import gradio as gr
 import numpy as np


### PR DESCRIPTION
I am getting this error on CachyOS Linux, and this simple commit fixes this:

```
<<PINOKIO_SHELL>>eval "$(conda shell.bash hook)" ; conda deactivate ; conda deactivate ; conda deactivate ; conda activate base ; source /home/dragon/pinokio/api/Qwen3-TTS-Pinokio.git/app/venv/bin/activate /home/dragon/pinokio/api/Qwen3-TTS-Pinokio.git/app/venv && python app.py
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try 'pacman -S
    python-xyz', where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Arch-packaged Python package,
    create a virtual environment using 'python -m venv path/to/venv'.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip.
    
    If you wish to install a non-Arch packaged Python application,
    it may be easiest to use 'pipx install xyz', which will manage a
    virtual environment for you. Make sure you have python-pipx
    installed via pacman.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.

``` 